### PR TITLE
add tray_monitor

### DIFF
--- a/cob_tray_monitor/CMakeLists.txt
+++ b/cob_tray_monitor/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 2.4.6)
+include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
+
+# Set the build type.  Options are:
+#  Coverage       : w/ debug symbols, w/o optimization, w/ code-coverage
+#  Debug          : w/ debug symbols, w/o optimization
+#  Release        : w/o debug symbols, w/ optimization
+#  RelWithDebInfo : w/ debug symbols, w/ optimization
+#  MinSizeRel     : w/o debug symbols, w/ optimization, stripped binaries
+#set(ROS_BUILD_TYPE RelWithDebInfo)
+
+rosbuild_init()
+
+#set the default path for built executables to the "bin" directory
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
+#set the default path for built libraries to the "lib" directory
+set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
+
+#uncomment if you have defined messages
+#rosbuild_genmsg()
+#uncomment if you have defined services
+#rosbuild_gensrv()
+
+#common commands for building c++ executables and libraries
+#rosbuild_add_library(${PROJECT_NAME} src/example.cpp)
+#target_link_libraries(${PROJECT_NAME} another_library)
+#rosbuild_add_boost_directories()
+#rosbuild_link_boost(${PROJECT_NAME} thread)
+#rosbuild_add_executable(example examples/example.cpp)
+#target_link_libraries(example ${PROJECT_NAME})

--- a/cob_tray_monitor/Makefile
+++ b/cob_tray_monitor/Makefile
@@ -1,0 +1,1 @@
+include $(shell rospack find mk)/cmake.mk

--- a/cob_tray_monitor/mainpage.dox
+++ b/cob_tray_monitor/mainpage.dox
@@ -1,0 +1,26 @@
+/**
+\mainpage
+\htmlinclude manifest.html
+
+\b cob_tray_monitor is ... 
+
+<!-- 
+Provide an overview of your package.
+-->
+
+
+\section codeapi Code API
+
+<!--
+Provide links to specific auto-generated API documentation within your
+package that is of particular interest to a reader. Doxygen will
+document pretty much every part of your code, so do your best here to
+point the reader to the actual API.
+
+If your codebase is fairly large or has different sets of APIs, you
+should use the doxygen 'group' tag to keep these APIs together. For
+example, the roscpp documentation has 'libros' group.
+-->
+
+
+*/

--- a/cob_tray_monitor/manifest.xml
+++ b/cob_tray_monitor/manifest.xml
@@ -1,0 +1,16 @@
+<package>
+  <description brief="cob_tray_monitor">
+
+     cob_tray_monitor
+
+  </description>
+  <author>Florian Weisshardt</author>
+  <license>LGPL</license>
+  <review status="unreviewed" notes=""/>
+  <url>http://ros.org/wiki/cob_tray_monitor</url>
+
+  <depend package="rospy"/>
+  <depend package="sensor_msgs"/>
+  <depend package="cob_srvs"/>
+
+</package>

--- a/cob_tray_monitor/ros/launch/tray_monitor.launch
+++ b/cob_tray_monitor/ros/launch/tray_monitor.launch
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<launch>
+
+	<rosparam ns="tray_monitor" file="$(find cob_tray_monitor)/config/monitor_params.yaml" command="load" />
+
+	<node ns="tray_monitor" pkg="cob_tray_monitor" type="tray_monitor.py" name="tray_monitor" respawn="false" output="screen"/>
+
+</launch>
+

--- a/cob_tray_monitor/ros/src/tray_monitor.py
+++ b/cob_tray_monitor/ros/src/tray_monitor.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+import roslib; roslib.load_manifest('cob_tray_monitor')
+import rospy
+import math
+from std_msgs.msg import *
+from sensor_msgs.msg import *
+from cob_srvs.srv import *
+
+class Monitor():
+    
+    def __init__(self):        
+        self.pub = rospy.Publisher("occupied", Bool)
+        rospy.Subscriber("/tray_sensors/range_1", Range, self.range1_callback)
+        rospy.Subscriber("/tray_sensors/range_2", Range, self.range2_callback)
+        rospy.Subscriber("/tray_sensors/range_3", Range, self.range3_callback)
+        rospy.Subscriber("/tray_sensors/range_4", Range, self.range4_callback)
+        rospy.Service('occupied', Trigger, self.srv_callback)
+        self.range1 = Range()
+        self.range2 = Range()
+        self.range3 = Range()
+        self.range4 = Range()
+        self.occupied = True
+        
+        if not rospy.has_param('distance_limit'):
+            rospy.logerr("no distance_limit specified")
+            exit(1)
+
+        self.limit = rospy.get_param('distance_limit')
+    
+    def srv_callback(self,req):
+        res = TriggerResponse()
+        res.success.data = self.occupied
+        return res
+
+    def range1_callback(self,msg):
+        self.range1 = msg
+    
+    def range2_callback(self,msg):
+        self.range2 = msg
+    
+    def range3_callback(self,msg):
+        self.range3 = msg
+    
+    def range4_callback(self,msg):
+        self.range4 = msg
+
+    def publish_state(self):
+        msg = Bool()
+        if self.range1.range <= self.limit:
+            msg.data = True;
+        if self.range2.range <= self.limit:
+            msg.data = True;
+        if self.range3.range <= self.limit:
+            msg.data = True;
+        if self.range4.range <= self.limit:
+            msg.data = True;
+
+        self.pub.publish(msg)
+
+if __name__ == "__main__":
+    rospy.init_node('tactile_sensors')
+    rospy.sleep(0.5)
+    
+    m = Monitor()
+    rospy.loginfo("tray monitor running")
+    
+    r = rospy.Rate(10)
+    while not rospy.is_shutdown():
+        m.publish_state()
+        r.sleep()

--- a/stack.xml
+++ b/stack.xml
@@ -8,20 +8,20 @@
   <license>LGPL</license>  
   <review status="unreviewed" notes=""/>
   <url>http://ros.org/wiki/cob_manipulation</url>
-  <depend stack="arm_navigation" /> <!-- move_arm, trajectory_filter_server, kinematics_base, robot_self_filter, constraint_aware_spline_smoother, arm_kinematics_constraint_aware, kinematics_msgs, planning_environment, arm_navigation_msgs, ompl_ros_interface -->
+  <depend stack="arm_navigation" /> <!-- move_arm, trajectory_filter_server, planning_environment, robot_self_filter, constraint_aware_spline_smoother, arm_kinematics_constraint_aware, kinematics_msgs, kinematics_base, arm_navigation_msgs, ompl_ros_interface -->
   <depend stack="arm_navigation_experimental" /> <!-- collider, move_arm_warehouse -->
   <depend stack="cob_command_tools" /> <!-- cob_script_server -->
   <depend stack="cob_common" /> <!-- cob_srvs, brics_actuator -->
   <depend stack="cob_robots" /> <!-- cob_hardware_config -->
   <depend stack="common" /> <!-- actionlib, tinyxml -->
-  <depend stack="common_msgs" /> <!-- nav_msgs, actionlib_msgs, trajectory_msgs, geometry_msgs, visualization_msgs -->
+  <depend stack="common_msgs" /> <!-- nav_msgs, actionlib_msgs, trajectory_msgs, sensor_msgs, geometry_msgs, visualization_msgs -->
   <depend stack="geometry" /> <!-- tf, tf_conversions -->
   <depend stack="object_manipulation" /> <!-- object_manipulation_msgs -->
   <depend stack="orocos_kinematics_dynamics" /> <!-- kdl -->
   <depend stack="pluginlib" /> <!-- pluginlib -->
   <depend stack="pr2_controllers" /> <!-- pr2_controllers_msgs -->
   <depend stack="pr2_kinematics" /> <!-- pr2_arm_kinematics -->
-  <depend stack="robot_model" /> <!-- collada_urdf, urdf, robot_state_publisher, kdl_parser -->
+  <depend stack="robot_model" /> <!-- robot_state_publisher, urdf, kdl_parser, collada_urdf -->
   <depend stack="ros" />
   <depend stack="ros_comm" /> <!-- std_msgs, rospy, roscpp -->
   <depend stack="schunk_modular_robotics" /> <!-- schunk_sdh -->


### PR DESCRIPTION
using the raw data of the tray sensors (phidgets range sensors) a occupied state of the tray is determined

working in simulation too: use the latest version of ipa320/cob_common and ipa320/cob_driver and ipa320/cob_robots
