### PR TITLE
Fix a Python indentation problem

### DIFF
--- a/cob_pick_place_action/scripts/cob_multi_pick_place_client.py
+++ b/cob_pick_place_action/scripts/cob_multi_pick_place_client.py
@@ -90,7 +90,7 @@ def cob_place_action_client(object_class, object_name, destinations):
 	goal.object_class = object_class
 	goal.object_name = object_name
 	goal.destinations = destinations
-    goal.support_surface = "bookcase"
+	goal.support_surface = "bookcase"
 	
 	#print goal
 	# Sends the goal to the action server.


### PR DESCRIPTION
This is a syntax error and prevents bytecompiling (and using) of this python script.

Found during Fedora packaging.
