### PR TITLE
add catkin_INCLUDE_DIRS to cob_kinematics

### DIFF
--- a/cob_kinematics/CMakeLists.txt
+++ b/cob_kinematics/CMakeLists.txt
@@ -33,7 +33,10 @@ catkin_package(
 ## Build ##
 ###########
 
-#include_directories(${PROJECT_SOURCE_DIR}/ros/include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  #${PROJECT_SOURCE_DIR}/ros/include
+)
 
 #add_executable(urdf_openrave ros/src/urdf_openrave.cpp)
 add_subdirectory(ikfast)


### PR DESCRIPTION
Example of break: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-cob-kinematics_binaryrpm_heisenbug_x86_64/9/console

I'm guessing that this works on your system because the urdf headers are placed directly in `/usr/include` while in Fedora, they are not.

Thanks,

--scott
