### PR TITLE
Collision monitor

### DIFF
--- a/cob_collision_monitor/CMakeLists.txt
+++ b/cob_collision_monitor/CMakeLists.txt
@@ -9,12 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   tf
 )
-catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES cob_collision_monitor
-#  CATKIN_DEPENDS moveit_ros_move_group moveit_ros_planning pluginlib std_msgs
-#  DEPENDS system_lib
-)
+catkin_package()
 
 include_directories(
   ${catkin_INCLUDE_DIRS}

--- a/cob_collision_monitor/CMakeLists.txt
+++ b/cob_collision_monitor/CMakeLists.txt
@@ -1,0 +1,171 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(cob_collision_monitor)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  moveit_ros_move_group
+  moveit_ros_planning
+  pluginlib
+  std_msgs
+  tf
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependencies might have been
+##     pulled in transitively but can be declared for certainty nonetheless:
+##     * add a build_depend tag for "message_generation"
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES cob_collision_monitor
+#  CATKIN_DEPENDS moveit_ros_move_group moveit_ros_planning pluginlib std_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a cpp library
+add_library(cob_collision_monitor_capability
+  src/collision_monitor_capability.cpp
+)
+
+## Declare a cpp executable
+add_executable(cob_collision_monitor_node src/collision_monitor_node.cpp)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+# add_dependencies(cob_collision_monitor_node cob_collision_monitor_generate_messages_cpp)
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(cob_collision_monitor_node
+  ${catkin_LIBRARIES}
+)
+target_link_libraries(cob_collision_monitor_capability
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+install(TARGETS cob_collision_monitor_capability cob_collision_monitor_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+install(FILES move_group_capabilities.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_cob_collision_monitor.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/cob_collision_monitor/CMakeLists.txt
+++ b/cob_collision_monitor/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(cob_collision_monitor)
 
 ## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   moveit_ros_move_group
   moveit_ros_planning
@@ -11,76 +9,6 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   tf
 )
-
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependencies might have been
-##     pulled in transitively but can be declared for certainty nonetheless:
-##     * add a build_depend tag for "message_generation"
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES cob_collision_monitor
@@ -88,28 +16,15 @@ catkin_package(
 #  DEPENDS system_lib
 )
 
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-## Declare a cpp library
 add_library(cob_collision_monitor_capability
   src/collision_monitor_capability.cpp
 )
 
-## Declare a cpp executable
 add_executable(cob_collision_monitor_node src/collision_monitor_node.cpp)
-
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
-# add_dependencies(cob_collision_monitor_node cob_collision_monitor_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(cob_collision_monitor_node
@@ -119,19 +34,6 @@ target_link_libraries(cob_collision_monitor_capability
   ${catkin_LIBRARIES}
 )
 
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
 
 ## Mark executables and/or libraries for installation
 install(TARGETS cob_collision_monitor_capability cob_collision_monitor_node
@@ -139,33 +41,7 @@ install(TARGETS cob_collision_monitor_capability cob_collision_monitor_node
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
 install(FILES move_group_capabilities.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_cob_collision_monitor.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/cob_collision_monitor/launch/collision_monitor.launch
+++ b/cob_collision_monitor/launch/collision_monitor.launch
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="load_robot_description" default="false"/>
+  <arg name="robot" default="$(env ROBOT)"/>
+  <arg name="config_path" default="$(find cob_moveit_config)/$(arg robot)/config"/>
+  
+  <!-- Load SRDF -->
+  <include file="$(find cob_moveit_config)/launch/planning_context.xml">
+    <arg name="load_robot_description" value="$(arg load_robot_description)" />
+    <arg name="robot" value="$(arg robot)" />
+    <arg name="config_path" value="$(arg config_path)" />
+  </include>
+
+  <node pkg="cob_collision_monitor" type="cob_collision_monitor_node" name="cob_collision_monitor_node"/>
+
+</launch>

--- a/cob_collision_monitor/move_group_capabilities.xml
+++ b/cob_collision_monitor/move_group_capabilities.xml
@@ -1,0 +1,6 @@
+<library path="lib/libcob_collision_monitor_capabilty">
+  <class type="cob_collision_monitor::CollisionMonitor" base_class_type="move_group::MoveGroupCapability">
+    <description>
+    </description>
+  </class>
+</library>

--- a/cob_collision_monitor/move_group_capabilities.xml
+++ b/cob_collision_monitor/move_group_capabilities.xml
@@ -1,5 +1,5 @@
 <library path="lib/libcob_collision_monitor_capability">
-  <class type="cob_collision_monitor::CollisionMonitor" base_class_type="move_group::MoveGroupCapability">
+  <class name="cob_collision_monitor/CollisionMonitor" type="cob_collision_monitor::CollisionMonitor" base_class_type="move_group::MoveGroupCapability">
     <description>
     </description>
   </class>

--- a/cob_collision_monitor/move_group_capabilities.xml
+++ b/cob_collision_monitor/move_group_capabilities.xml
@@ -1,4 +1,4 @@
-<library path="lib/libcob_collision_monitor_capabilty">
+<library path="lib/libcob_collision_monitor_capability">
   <class type="cob_collision_monitor::CollisionMonitor" base_class_type="move_group::MoveGroupCapability">
     <description>
     </description>

--- a/cob_collision_monitor/package.xml
+++ b/cob_collision_monitor/package.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>cob_collision_monitor</name>
+  <version>0.0.0</version>
+  <description>The collision monitor uses the planning scene monitor to read the state of the robot and check it for collision with itselt or the environment. It addition a ground plane is added in any case. Can be used as a stand-aloan node or a move_group capability.</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>LGPLv3</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/cob_collision_monitor</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>moveit_ros_move_group</depend>
+  <depend>moveit_ros_planning</depend>
+  <depend>pluginlib</depend>
+  <depend>std_msgs</depend>
+  <depend>tf</depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <moveit_ros_move_group plugin="${prefix}/move_group_capabilities.xml"/>
+  </export>
+</package>

--- a/cob_collision_monitor/package.xml
+++ b/cob_collision_monitor/package.xml
@@ -4,29 +4,13 @@
   <version>0.0.0</version>
   <description>The collision monitor uses the planning scene monitor to read the state of the robot and check it for collision with itselt or the environment. It addition a ground plane is added in any case. Can be used as a stand-aloan node or a move_group capability.</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>LGPLv3</license>
 
+  <url type="website">http://wiki.ros.org/cob_collision_monitor</url>
 
-  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/cob_collision_monitor</url> -->
-
-
-  <!-- Author tags are optional, mutiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintianers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
+  <author email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</author>
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>moveit_ros_move_group</depend>
@@ -35,7 +19,6 @@
   <depend>std_msgs</depend>
   <depend>tf</depend>
 
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
     <moveit_ros_move_group plugin="${prefix}/move_group_capabilities.xml"/>
   </export>

--- a/cob_collision_monitor/package.xml
+++ b/cob_collision_monitor/package.xml
@@ -18,6 +18,8 @@
   <depend>pluginlib</depend>
   <depend>std_msgs</depend>
   <depend>tf</depend>
+  
+  <exec_depend>cob_moveit_config</exec_depend>
 
   <export>
     <moveit_ros_move_group plugin="${prefix}/move_group_capabilities.xml"/>

--- a/cob_collision_monitor/src/collision_monitor_capability.cpp
+++ b/cob_collision_monitor/src/collision_monitor_capability.cpp
@@ -1,0 +1,19 @@
+#include <moveit/move_group/move_group_capability.h>
+#include "valid_state_publisher.h"
+
+namespace cob_collision_monitor{
+class CollisionMonitor : public move_group::MoveGroupCapability
+{
+    boost::scoped_ptr<ValidStatePublisher> vsp_;
+    virtual void initialize(){
+        vsp_.reset(new ValidStatePublisher(node_handle_, context_->planning_scene_monitor_));
+    }
+public:
+    CollisionMonitor(): MoveGroupCapability("CollisionMonitor")
+    {
+    }
+};
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(cob_collision_monitor::CollisionMonitor, move_group::MoveGroupCapability)

--- a/cob_collision_monitor/src/collision_monitor_node.cpp
+++ b/cob_collision_monitor/src/collision_monitor_node.cpp
@@ -1,0 +1,28 @@
+#include "valid_state_publisher.h"
+
+
+int main(int argc, char **argv)
+{
+    ros::init (argc, argv, "collision_monitor_node");
+
+    ros::NodeHandle nh("~");
+
+    boost::shared_ptr<tf::TransformListener> tf(new tf::TransformListener(ros::Duration(nh.param("max_cache_time", 2.0))));
+    planning_scene_monitor::PlanningSceneMonitorPtr psm(new planning_scene_monitor::PlanningSceneMonitor("robot_description", tf));
+
+    double state_update_frequency;
+    if(nh.getParam("state_update_frequency", state_update_frequency))
+        psm->setStateUpdateFrequency(state_update_frequency);
+
+    if(nh.param("start_scene_monitor", true))
+        psm->startSceneMonitor();
+    if(nh.param("start_world_geometry_monitor", true))
+        psm->startWorldGeometryMonitor();
+    psm->startStateMonitor();
+
+    cob_collision_monitor::ValidStatePublisher vsp(nh, psm);
+
+    ros::spin();
+
+    return 0;
+}

--- a/cob_collision_monitor/src/valid_state_publisher.h
+++ b/cob_collision_monitor/src/valid_state_publisher.h
@@ -1,0 +1,75 @@
+#ifndef COB_COLLISION_MONITOR_VALID_STATE_PUBLISHER_H
+#define COB_COLLISION_MONITOR_VALID_STATE_PUBLISHER_H
+
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
+#include <std_msgs/Bool.h>
+
+namespace cob_collision_monitor{
+class ValidStatePublisher{
+    planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
+    bool was_complete_;
+    ros::Duration max_age_;
+    ros::Publisher pub_;
+    std_msgs::Bool data_;
+    bool verbose_;
+    moveit_msgs::PlanningScene diff_msg_;
+public:
+    ValidStatePublisher(ros::NodeHandle nh, planning_scene_monitor::PlanningSceneMonitorPtr psm)
+    : planning_scene_monitor_(psm),
+      was_complete_(false),
+      max_age_(nh.param("max_age", 1.0)),
+      pub_(nh.advertise<std_msgs::Bool>("state_is_valid", 1)),
+      data_(),
+      verbose_(nh.param("verbose", true))
+    {
+        if(nh.param("add_ground",true)){
+
+            moveit_msgs::CollisionObject co;
+            co.header.frame_id = nh.param("ground_link",std::string("base_link"));
+            co.id ="_ground_plane_";
+
+            double box_size;
+            if(nh.getParam("ground_box_size", box_size)){
+                co.primitives.resize(1);
+                co.primitives.front().type = shape_msgs::SolidPrimitive::BOX;
+                co.primitives.front().dimensions.resize(3);
+                co.primitives.front().dimensions[0] = box_size;
+                co.primitives.front().dimensions[1] = box_size;
+                co.primitives.front().dimensions[2] = 0.01;
+                co.primitive_poses.resize(1);
+                co.primitive_poses.front().position.z = -0.005 + nh.param("ground_height",-0.001);
+                co.primitive_poses.front().orientation.w = 1.0;
+            }else{
+                co.planes.resize(1);
+                co.planes.front().coef[2] = 1; // only z, parallel to xy-plane
+                co.plane_poses.resize(1);
+                co.plane_poses.front().position.z = nh.param("ground_height",-0.001);
+                co.plane_poses.front().orientation.w = 1.0;
+            }
+            diff_msg_.world.collision_objects.push_back(co);
+            diff_msg_.is_diff = true;
+        }
+
+        data_.data = true;
+
+        planning_scene_monitor_->addUpdateCallback(boost::bind(&ValidStatePublisher::updatedScene,this,_1));
+    }
+
+
+    void updatedScene(planning_scene_monitor::PlanningSceneMonitor::SceneUpdateType type){
+        planning_scene_monitor::CurrentStateMonitorPtr csm = planning_scene_monitor_->getStateMonitor();
+        bool complete = max_age_.isZero() ? csm->haveCompleteState() : csm->haveCompleteState(max_age_);
+        if(complete){
+            was_complete_ = true;
+            planning_scene_monitor::LockedPlanningSceneRO ps(planning_scene_monitor_);
+            planning_scene::PlanningScenePtr diff_ps = ps->diff(diff_msg_);
+            data_.data = !diff_ps->isStateColliding("", verbose_);
+        }else if(was_complete_){
+            data_.data = false;
+        }
+        pub_.publish(data_);
+    }
+};
+}
+
+#endif

--- a/cob_collision_monitor/src/valid_state_publisher.h
+++ b/cob_collision_monitor/src/valid_state_publisher.h
@@ -22,19 +22,20 @@ public:
       data_(),
       verbose_(nh.param("verbose", true))
     {
-        if(nh.param("add_ground",true)){
+        double ground_size = nh.param("ground_size", 10.0);
+         
+        if(ground_size != 0.0){
 
             moveit_msgs::CollisionObject co;
             co.header.frame_id = nh.param("ground_link",std::string("base_link"));
             co.id ="_ground_plane_";
 
-            double box_size;
-            if(nh.getParam("ground_box_size", box_size)){
+            if(ground_size > 0){
                 co.primitives.resize(1);
                 co.primitives.front().type = shape_msgs::SolidPrimitive::BOX;
                 co.primitives.front().dimensions.resize(3);
-                co.primitives.front().dimensions[0] = box_size;
-                co.primitives.front().dimensions[1] = box_size;
+                co.primitives.front().dimensions[0] = ground_size;
+                co.primitives.front().dimensions[1] = ground_size;
                 co.primitives.front().dimensions[2] = 0.01;
                 co.primitive_poses.resize(1);
                 co.primitive_poses.front().position.z = -0.005 + nh.param("ground_height",-0.001);

--- a/cob_moveit_config/launch/move_group.launch
+++ b/cob_moveit_config/launch/move_group.launch
@@ -67,6 +67,8 @@
                                       move_group/MoveGroupStateValidationService
                                       move_group/MoveGroupGetPlanningSceneService
                                       " />
+                                      <!-- you can add 'cob_collision_monitor/CollisionMonitor' to the list above
+                                           however, it is recommended to use the standalone-node in cob_collision_monitor -->
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
     <param name="planning_scene_monitor/publish_planning_scene" value="$(arg publish_monitored_planning_scene)" />


### PR DESCRIPTION
this is a rebase of #54 

The description given in #54 has slightly changed:
- `~add_ground` boolean parameter has been removed
- `~ground_box_size` double parameter has been removed
- **new** double parameter `~ground_size` is used to determine whether
  - no ground is added (`ground_size == 0`)
  - ground box is added (`ground_size > 0`)
  - ground plane is added (`ground_size < 0`)
- default value for `~ground_size` is 10.0 (in order to circum-pass the [fcl bug](https://github.com/flexible-collision-library/fcl/issues/12) mentioned by @ipa-mdl)

An launch file for the stand-alone node was added and can be used as:
`roslaunch cob_collision_monitor collision_monitor.launch` with e.g. `robot:=cob4-2` as launch file argument
