### PR TITLE
properly pass missing launch arguments

### DIFF
--- a/cob_moveit_bringup/launch/demo.launch
+++ b/cob_moveit_bringup/launch/demo.launch
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
+  <arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
   <arg name="pkg_moveit_config" default="$(find cob_moveit_config)"/>
   <arg name="with_db" default="false"/>
   <arg name="debug" default="false"/>
@@ -17,6 +18,8 @@
 
   <include file="$(find cob_moveit_bringup)/launch/move_group.launch">
     <arg name="robot" value="$(arg robot)"/>
+    <arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)"/>
+    <arg name="pkg_moveit_config" value="$(arg pkg_moveit_config)"/>
     <arg name="load_robot_description" value="true"/>
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
@@ -28,6 +31,7 @@
 
   <include file="$(find cob_moveit_bringup)/launch/rviz.launch">
     <arg name="robot" value="$(arg robot)"/>
+    <arg name="pkg_moveit_config" value="$(arg pkg_moveit_config)"/>
     <arg name="config" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>

--- a/cob_moveit_bringup/launch/move_group.launch
+++ b/cob_moveit_bringup/launch/move_group.launch
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
+  <arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
   <arg name="pkg_moveit_config" default="$(find cob_moveit_config)"/>
   <arg name="config_path" default="$(arg pkg_moveit_config)/robots/$(arg robot)/moveit/config"/>
   <arg name="load_robot_description" default="false"/>
@@ -27,11 +28,14 @@
   <!-- Planning Functionality -->
   <include file="$(find cob_moveit_bringup)/launch/planning_context.xml">
     <arg name="robot" value="$(arg robot)"/>
+    <arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)"/>
+    <arg name="pkg_moveit_config" value="$(arg pkg_moveit_config)"/>
     <arg name="load_robot_description" value="$(arg load_robot_description)"/>
   </include>
 
   <include ns="move_group" file="$(find cob_moveit_bringup)/launch/planning_pipeline.xml">
     <arg name="robot" value="$(arg robot)"/>
+    <arg name="pkg_moveit_config" value="$(arg pkg_moveit_config)"/>
     <arg name="pipeline" value="$(arg pipeline)"/>
   </include>
 

--- a/cob_moveit_bringup/launch/planning_context.xml
+++ b/cob_moveit_bringup/launch/planning_context.xml
@@ -1,6 +1,7 @@
 <launch>
 
   <arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
+  <arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
   <arg name="pkg_moveit_config" default="$(find cob_moveit_config)"/>
   <arg name="config_path" default="$(arg pkg_moveit_config)/robots/$(arg robot)/moveit/config"/>
 
@@ -13,7 +14,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robotic description format (URDF) -->
-  <include file="$(find cob_hardware_config)/upload_robot.launch" if="$(arg load_robot_description)">
+  <include file="$(arg pkg_hardware_config)/upload_robot.launch" if="$(arg load_robot_description)">
     <arg name="robot" value="$(arg robot)" />
   </include>
 

--- a/cob_moveit_bringup/launch/planning_pipeline.xml
+++ b/cob_moveit_bringup/launch/planning_pipeline.xml
@@ -4,10 +4,12 @@
        It is assumed that all planning pipelines are named XXX_planning_pipeline.launch  -->
 
   <arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
+  <arg name="pkg_moveit_config" default="$(find cob_moveit_config)"/>
   <arg name="pipeline" default="ompl"/>
 
   <include file="$(find cob_moveit_bringup)/launch/$(arg pipeline)_planning_pipeline.xml">
     <arg name="robot" value="$(arg robot)"/>
+    <arg name="pkg_moveit_config" value="$(arg pkg_moveit_config)"/>
   </include>
 
 </launch>


### PR DESCRIPTION
some launch arguments were not properly passed through cob_moveit_bringup in order to be able to use cob_moveit_bringup together with a moveit_config package located in a different location

full backwards compatibility is guaranteed through proper default values...