### PR TITLE
additional arguments for moveit_config helper

### DIFF
--- a/cob_moveit_bringup/bin/add_robot.sh
+++ b/cob_moveit_bringup/bin/add_robot.sh
@@ -10,17 +10,17 @@ echo "Adding moveit_config for "$robot" in "$pkg_moveit_config
 
 mkdir -p $pkg_moveit_config/robots/$robot/moveit/config
 
-cat <<SRDF_TEMPLATE  | sed "s/ROBOT/$robot/g" > $pkg_moveit_config/robots/$robot/moveit/config/$robot.srdf
-<robot name="ROBOT">
+cat <<SRDF_TEMPLATE > $pkg_moveit_config/robots/$robot/moveit/config/$robot.srdf
+<robot name="$robot">
 </robot>
 SRDF_TEMPLATE
 
-cat <<CONFIG_TEMPLATE  | sed "s/ROBOT/$robot/g;s/PKG_HARDWARE_CONFIG_NAME/$pkg_hardware_config_name/g" > $pkg_moveit_config/robots/$robot/moveit/.setup_assistant
+cat <<CONFIG_TEMPLATE > $pkg_moveit_config/robots/$robot/moveit/.setup_assistant
 moveit_setup_assistant_config:
   URDF:
-    package: PKG_HARDWARE_CONFIG_NAME
-    relative_path: robots/ROBOT/urdf/ROBOT.urdf.xacro
+    package: $pkg_hardware_config_name
+    relative_path: robots/$robot/urdf/$robot.urdf.xacro
     use_jade_xacro: true
   SRDF:
-    relative_path: config/ROBOT.srdf
+    relative_path: config/$robot.srdf
 CONFIG_TEMPLATE

--- a/cob_moveit_bringup/bin/add_robot.sh
+++ b/cob_moveit_bringup/bin/add_robot.sh
@@ -1,2 +1,25 @@
 #!/bin/bash
-rosrun cob_moveit_config add_robot.sh "$@"
+
+robot=$1
+pkg_moveit_config_name=${2:-cob_moveit_config}
+pkg_hardware_config_name=${3:-cob_hardware_config}
+
+pkg_moveit_config=`rospack find $pkg_moveit_config_name`
+
+echo "Adding moveit_config for "$robot" in "$pkg_moveit_config
+
+mkdir -p $pkg_moveit_config/robots/$robot/moveit/config
+
+cat <<SRDF_TEMPLATE  | sed "s/ROBOT/$robot/g" > $pkg_moveit_config/robots/$robot/moveit/config/$robot.srdf
+<robot name="ROBOT">
+</robot>
+SRDF_TEMPLATE
+
+cat <<CONFIG_TEMPLATE  | sed "s/ROBOT/$robot/g;s/PKG_HARDWARE_CONFIG_NAME/$pkg_hardware_config_name/g" > $pkg_moveit_config/robots/$robot/moveit/.setup_assistant
+moveit_setup_assistant_config:
+  URDF:
+    package: PKG_HARDWARE_CONFIG_NAME
+    relative_path: robots/ROBOT/urdf/ROBOT.urdf.xacro
+  SRDF:
+    relative_path: config/ROBOT.srdf
+CONFIG_TEMPLATE

--- a/cob_moveit_bringup/bin/add_robot.sh
+++ b/cob_moveit_bringup/bin/add_robot.sh
@@ -20,6 +20,7 @@ moveit_setup_assistant_config:
   URDF:
     package: PKG_HARDWARE_CONFIG_NAME
     relative_path: robots/ROBOT/urdf/ROBOT.urdf.xacro
+    use_jade_xacro: true
   SRDF:
     relative_path: config/ROBOT.srdf
 CONFIG_TEMPLATE

--- a/cob_moveit_bringup/bin/update_collisions.sh
+++ b/cob_moveit_bringup/bin/update_collisions.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 robot=$1
+pkg_moveit_config_name=${2:-cob_moveit_config}
 
-moveit_config=`rospack find cob_moveit_config`
-config_pkg=$moveit_config/robots/$robot/moveit
+pkg_moveit_config=`rospack find $pkg_moveit_config_name`
 
-echo "Updating collisions in "$config_pkg
+echo "Updating collisions for "$robot" in "$pkg_moveit_config
 
-rosrun moveit_setup_assistant collisions_updater --config-pkg $config_pkg --default --always --keep --trials 100000 --xacro-args '--inorder'
+robot_config=$pkg_moveit_config/robots/$robot/moveit
+rosrun moveit_setup_assistant collisions_updater --config-pkg $robot_config --default --always --keep --trials 100000 --xacro-args '--inorder'
 
-echo "Please review changes in "$config_pkg" and provide PR!"
+echo "Please review changes in "$robot_config" and provide PR!"


### PR DESCRIPTION
you can now pass additional arguments to the helper, i.e. `pkg_moveit_config_name` and `pkg_hardware_config_name`, in order to use the helper to generate and update moveit_configs at other locations as well - as long as they follow the `cob_moveit_config` structure
(defaults are still `cob_moveit_config` and `cob_hardware_config` if the additional arguments are not set)

@ipa-aep @ipa-bfb please review/test

also:
fixes https://github.com/ipa320/cob_manipulation/issues/105
see https://github.com/ipa320/cob_manipulation/issues/105#issuecomment-338577913