### PR TITLE
add ROS_DISTRO condition for --inorder

### DIFF
--- a/cob_moveit_bringup/bin/update_collisions.sh
+++ b/cob_moveit_bringup/bin/update_collisions.sh
@@ -4,10 +4,11 @@ robot=$1
 pkg_moveit_config_name=${2:-cob_moveit_config}
 
 pkg_moveit_config=`rospack find $pkg_moveit_config_name`
+[[ "$ROS_DISTRO" < "melodic" ]] && xacro_args='--xacro-args --inorder' || xacro_args=''
 
 echo "Updating collisions for "$robot" in "$pkg_moveit_config
 
 robot_config=$pkg_moveit_config/robots/$robot/moveit
-rosrun moveit_setup_assistant collisions_updater --config-pkg $robot_config --default --always --keep --trials 100000 --xacro-args '--inorder'
+rosrun moveit_setup_assistant collisions_updater --config-pkg $robot_config --default --always --keep --trials 100000 $xacro_args
 
 echo "Please review changes in "$robot_config" and provide PR!"


### PR DESCRIPTION
ref https://github.com/mojin-robotics/cob4/issues/1399
`--inorder` is default since melodic